### PR TITLE
fix: add type annotations to global lists for mypy compliance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.0
+    rev: v1.20.1
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.1
+    rev: v1.20.2
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: v1.20.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests]

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ filelock==3.29.0
     #   virtualenv
 identify==2.6.19
     # via pre-commit
-idna==3.11
+idna==3.12
     # via requests
 iniconfig==2.3.0
     # via pytest
@@ -43,7 +43,7 @@ platformdirs==4.9.6
     #   virtualenv
 pluggy==1.6.0
     # via pytest
-pre-commit==4.5.1
+pre-commit==4.6.0
     # via -r requirements.in
 pygments==2.20.0
     # via pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-click==8.3.1
+click==8.3.2
     # via pip-tools
 distlib==0.4.0
     # via virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ typing-extensions==4.15.0
     #   virtualenv
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.1
+virtualenv==21.2.2
     # via pre-commit
 wheel==0.46.3
     # via pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,9 +51,9 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==9.0.2
+pytest==9.0.3
     # via -r requirements.in
-python-discovery==1.2.1
+python-discovery==1.2.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ distlib==0.4.0
     # via virtualenv
 exceptiongroup==1.3.1
     # via pytest
-filelock==3.25.2
+filelock==3.28.0
     # via
     #   python-discovery
     #   virtualenv
@@ -30,7 +30,7 @@ iniconfig==2.3.0
     # via pytest
 nodeenv==1.10.0
     # via pre-commit
-packaging==26.0
+packaging==26.1
     # via
     #   build
     #   pytest
@@ -72,7 +72,7 @@ typing-extensions==4.15.0
     #   virtualenv
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.2
+virtualenv==21.2.4
     # via pre-commit
 wheel==0.46.3
     # via pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ filelock==3.28.0
     # via
     #   python-discovery
     #   virtualenv
-identify==2.6.18
+identify==2.6.19
     # via pre-commit
 idna==3.11
     # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ iniconfig==2.3.0
     # via pytest
 nodeenv==1.10.0
     # via pre-commit
-packaging==26.1
+packaging==26.2
     # via
     #   build
     #   pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.6
     # via requests
 click==8.3.1
     # via pip-tools
@@ -22,7 +22,7 @@ filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
@@ -59,7 +59,7 @@ pyyaml==6.0.3
     # via pre-commit
 requests==2.32.5
     # via -r requirements.in
-squiral==0.5.0
+squiral==0.5.1
     # via -r requirements.in
 tomli==2.4.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ packaging==26.0
     #   wheel
 pip-tools==7.5.3
     # via -r requirements.in
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   python-discovery
     #   virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pytest==9.0.2
     # via -r requirements.in
-python-discovery==1.1.3
+python-discovery==1.2.0
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
 click==8.3.1
     # via pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pytest==9.0.2
     # via -r requirements.in
-python-discovery==1.2.0
+python-discovery==1.2.1
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ python-discovery==1.2.1
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via -r requirements.in
 squiral==0.5.1
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile
 #
-build==1.4.3
+build==1.4.4
     # via pip-tools
-certifi==2026.2.25
+certifi==2026.4.22
     # via requests
 cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-click==8.3.2
+click==8.3.3
     # via pip-tools
 distlib==0.4.0
     # via virtualenv
@@ -24,7 +24,7 @@ filelock==3.29.0
     #   virtualenv
 identify==2.6.19
     # via pre-commit
-idna==3.12
+idna==3.13
     # via requests
 iniconfig==2.3.0
     # via pytest
@@ -74,7 +74,7 @@ urllib3==2.6.3
     # via requests
 virtualenv==21.2.4
     # via pre-commit
-wheel==0.46.3
+wheel==0.47.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ typing-extensions==4.15.0
     #   virtualenv
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.4
+virtualenv==21.3.0
     # via pre-commit
 wheel==0.47.0
     # via pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ distlib==0.4.0
     # via virtualenv
 exceptiongroup==1.3.1
     # via pytest
-filelock==3.28.0
+filelock==3.29.0
     # via
     #   python-discovery
     #   virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ typing-extensions==4.15.0
     #   virtualenv
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
 wheel==0.46.3
     # via pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-build==1.4.1
+build==1.4.2
     # via pip-tools
 certifi==2026.2.25
     # via requests
@@ -57,11 +57,11 @@ python-discovery==1.2.0
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.32.5
+requests==2.33.0
     # via -r requirements.in
 squiral==0.5.1
     # via -r requirements.in
-tomli==2.4.0
+tomli==2.4.1
     # via
     #   build
     #   pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ pluggy==1.6.0
     # via pytest
 pre-commit==4.5.1
     # via -r requirements.in
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
 pyproject-hooks==1.2.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-build==1.4.2
+build==1.4.3
     # via pip-tools
 certifi==2026.2.25
     # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-build==1.4.0
+build==1.4.1
     # via pip-tools
 certifi==2026.2.25
     # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-build==1.4.4
+build==1.5.0
     # via pip-tools
 certifi==2026.4.22
     # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pytest==9.0.3
     # via -r requirements.in
-python-discovery==1.2.2
+python-discovery==1.3.0
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
@@ -72,7 +72,7 @@ typing-extensions==4.15.0
     #   virtualenv
 urllib3==2.6.3
     # via requests
-virtualenv==21.3.0
+virtualenv==21.3.1
     # via pre-commit
 wheel==0.47.0
     # via pip-tools

--- a/socials.py
+++ b/socials.py
@@ -7,11 +7,11 @@ import re
 
 import requests
 
-twitter = []
-instagram = []
-mastodon = []
-github = []
-found = []
+twitter: list[dict] = []
+instagram: list[dict] = []
+mastodon: list[dict] = []
+github: list[dict] = []
+found: list[str] = []
 
 
 def ayikla(adresler):


### PR DESCRIPTION
## Summary
- Add `list[dict]` annotation to `twitter`, `instagram`, `mastodon`, `github`
- Add `list[str]` annotation to `found`
- Fixes 5 mypy `var-annotated` errors in CI

## Test plan
- [x] `pre-commit run --all-files` passes (mypy hook green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)