### PR TITLE
fix: bump all GHA actions to latest major versions for Node.js 24

### DIFF
--- a/.github/workflows/update-dev-branch.yml
+++ b/.github/workflows/update-dev-branch.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/upgrader.yml
+++ b/.github/workflows/upgrader.yml
@@ -20,7 +20,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: dev
 

--- a/.github/workflows/upgrader.yml
+++ b/.github/workflows/upgrader.yml
@@ -25,7 +25,7 @@ jobs:
         ref: dev
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
         cache: pip
@@ -34,7 +34,7 @@ jobs:
       id: date
       run: echo "week=$(date +'%U')" >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       if: startsWith(runner.os, 'Linux')
       with:
         path: ~/.cache/pre-commit
@@ -49,7 +49,7 @@ jobs:
         pre-commit autoupdate
         pre-commit run --all-files --color always
 
-    - uses: stefanzweifel/git-auto-commit-action@v5
+    - uses: stefanzweifel/git-auto-commit-action@v7
       with:
         commit_message: ":arrow_up: Upgrade dependencies"
         branch: dev


### PR DESCRIPTION
## Summary

All actions were running on Node.js 20 (deprecated Jun 2 2026, removed Sep 16 2026).

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `v4` | `v6` |
| `actions/setup-python` | `v5` | `v6` |
| `actions/cache` | `v4` | `v5` |
| `stefanzweifel/git-auto-commit-action` | `v5` | `v7` |

## Test plan

- [ ] `update-dev` workflow runs without Node.js 20 deprecation warning
- [ ] `upgrader` workflow runs without Node.js 20 deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)