### PR TITLE
Dev->Master

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     -   id: reorder-python-imports
         args: [--py310-plus]
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.5.0
+    rev: 26.5.1
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.0.0
+    rev: v2.1.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.2.0
+    rev: v2.3.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     -   id: pyupgrade
         args: [--py310-plus]
 -   repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.16.0
+    rev: v3.17.0
     hooks:
     -   id: reorder-python-imports
         args: [--py310-plus]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0
+    rev: v2.2.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     -   id: reorder-python-imports
         args: [--py310-plus]
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.3.1
+    rev: 26.5.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-build==1.5.0
+build==1.5.1
     # via pip-tools
 certifi==2026.6.17
     # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ filelock==3.29.0
     #   virtualenv
 identify==2.6.19
     # via pre-commit
-idna==3.15
+idna==3.16
     # via requests
 iniconfig==2.3.0
     # via pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ pyyaml==6.0.3
     # via pre-commit
 requests==2.34.2
     # via -r requirements.in
-squiral==0.5.1
+squiral==0.6.0
     # via -r requirements.in
 tomli==2.4.1
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ python-discovery==1.3.1
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.34.1
+requests==2.34.2
     # via -r requirements.in
 squiral==0.5.1
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ charset-normalizer==3.4.7
     # via requests
 click==8.4.1
     # via pip-tools
-distlib==0.4.0
+distlib==0.4.1
     # via virtualenv
 exceptiongroup==1.3.1
     # via pytest
@@ -24,7 +24,7 @@ filelock==3.29.0
     #   virtualenv
 identify==2.6.19
     # via pre-commit
-idna==3.17
+idna==3.18
     # via requests
 iniconfig==2.3.0
     # via pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ python-discovery==1.3.1
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.34.0
+requests==2.34.1
     # via -r requirements.in
 squiral==0.5.1
     # via -r requirements.in
@@ -72,7 +72,7 @@ typing-extensions==4.15.0
     #   virtualenv
 urllib3==2.7.0
     # via requests
-virtualenv==21.3.2
+virtualenv==21.3.3
     # via pre-commit
 wheel==0.47.0
     # via pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ distlib==0.4.1
     # via virtualenv
 exceptiongroup==1.3.1
     # via pytest
-filelock==3.29.0
+filelock==3.29.1
     # via
     #   python-discovery
     #   virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ distlib==0.4.3
     # via virtualenv
 exceptiongroup==1.3.1
     # via pytest
-filelock==3.29.3
+filelock==3.29.4
     # via
     #   python-discovery
     #   virtualenv
@@ -51,7 +51,7 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==9.0.3
+pytest==9.1.0
     # via -r requirements.in
 python-discovery==1.4.2
     # via virtualenv
@@ -72,7 +72,7 @@ typing-extensions==4.15.0
     #   virtualenv
 urllib3==2.7.0
     # via requests
-virtualenv==21.4.3
+virtualenv==21.5.0
     # via pre-commit
 wheel==0.47.0
     # via pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ filelock==3.29.0
     #   virtualenv
 identify==2.6.19
     # via pre-commit
-idna==3.13
+idna==3.14
     # via requests
 iniconfig==2.3.0
     # via pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-click==8.3.3
+click==8.4.0
     # via pip-tools
 distlib==0.4.0
     # via virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ typing-extensions==4.15.0
     #   virtualenv
 urllib3==2.7.0
     # via requests
-virtualenv==21.5.0
+virtualenv==21.5.1
     # via pre-commit
 wheel==0.47.0
     # via pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ certifi==2026.6.17
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.8
+charset-normalizer==3.4.9
     # via requests
 click==8.4.2
     # via pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ filelock==3.29.0
     #   virtualenv
 identify==2.6.19
     # via pre-commit
-idna==3.16
+idna==3.17
     # via requests
 iniconfig==2.3.0
     # via pytest
@@ -37,7 +37,7 @@ packaging==26.2
     #   wheel
 pip-tools==7.5.3
     # via -r requirements.in
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via
     #   python-discovery
     #   virtualenv
@@ -53,7 +53,7 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pytest==9.0.3
     # via -r requirements.in
-python-discovery==1.3.2
+python-discovery==1.4.0
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
@@ -72,7 +72,7 @@ typing-extensions==4.15.0
     #   virtualenv
 urllib3==2.7.0
     # via requests
-virtualenv==21.3.3
+virtualenv==21.4.1
     # via pre-commit
 wheel==0.47.0
     # via pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ certifi==2026.6.17
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.7
+charset-normalizer==3.4.8
     # via requests
 click==8.4.2
     # via pip-tools
@@ -18,7 +18,7 @@ distlib==0.4.3
     # via virtualenv
 exceptiongroup==1.3.1
     # via pytest
-filelock==3.29.5
+filelock==3.29.6
     # via
     #   python-discovery
     #   virtualenv
@@ -72,7 +72,7 @@ typing-extensions==4.16.0
     #   virtualenv
 urllib3==2.7.0
     # via requests
-virtualenv==21.5.1
+virtualenv==21.6.0
     # via pre-commit
 wheel==0.47.0
     # via pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-click==8.4.1
+click==8.4.2
     # via pip-tools
 distlib==0.4.3
     # via virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ tomli==2.4.1
     #   build
     #   pip-tools
     #   pytest
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   exceptiongroup
     #   virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ distlib==0.4.2
     # via virtualenv
 exceptiongroup==1.3.1
     # via pytest
-filelock==3.29.1
+filelock==3.29.3
     # via
     #   python-discovery
     #   virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pytest==9.0.3
     # via -r requirements.in
-python-discovery==1.4.0
+python-discovery==1.4.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
@@ -72,7 +72,7 @@ typing-extensions==4.15.0
     #   virtualenv
 urllib3==2.7.0
     # via requests
-virtualenv==21.4.2
+virtualenv==21.4.3
     # via pre-commit
 wheel==0.47.0
     # via pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pytest==9.0.3
     # via -r requirements.in
-python-discovery==1.3.1
+python-discovery==1.3.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ filelock==3.29.0
     #   virtualenv
 identify==2.6.19
     # via pre-commit
-idna==3.14
+idna==3.15
     # via requests
 iniconfig==2.3.0
     # via pytest
@@ -53,7 +53,7 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pytest==9.0.3
     # via -r requirements.in
-python-discovery==1.3.0
+python-discovery==1.3.1
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
@@ -72,7 +72,7 @@ typing-extensions==4.15.0
     #   virtualenv
 urllib3==2.7.0
     # via requests
-virtualenv==21.3.1
+virtualenv==21.3.2
     # via pre-commit
 wheel==0.47.0
     # via pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ distlib==0.4.3
     # via virtualenv
 exceptiongroup==1.3.1
     # via pytest
-filelock==3.29.6
+filelock==3.29.7
     # via
     #   python-discovery
     #   virtualenv
@@ -53,7 +53,7 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pytest==9.1.1
     # via -r requirements.in
-python-discovery==1.4.3
+python-discovery==1.4.4
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==9.1.0
+pytest==9.1.1
     # via -r requirements.in
 python-discovery==1.4.2
     # via virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ typing-extensions==4.15.0
     #   virtualenv
 urllib3==2.7.0
     # via requests
-virtualenv==21.4.1
+virtualenv==21.4.2
     # via pre-commit
 wheel==0.47.0
     # via pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ charset-normalizer==3.4.7
     # via requests
 click==8.4.1
     # via pip-tools
-distlib==0.4.2
+distlib==0.4.3
     # via virtualenv
 exceptiongroup==1.3.1
     # via pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ python-discovery==1.3.0
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.1
+requests==2.34.0
     # via -r requirements.in
 squiral==0.5.1
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ charset-normalizer==3.4.7
     # via requests
 click==8.4.1
     # via pip-tools
-distlib==0.4.1
+distlib==0.4.2
     # via virtualenv
 exceptiongroup==1.3.1
     # via pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-click==8.4.0
+click==8.4.1
     # via pip-tools
 distlib==0.4.0
     # via virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 build==1.5.0
     # via pip-tools
-certifi==2026.5.20
+certifi==2026.6.17
     # via requests
 cfgv==3.5.0
     # via pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ typing-extensions==4.16.0
     #   virtualenv
 urllib3==2.7.0
     # via requests
-virtualenv==21.6.0
+virtualenv==21.6.1
     # via pre-commit
 wheel==0.47.0
     # via pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 build==1.5.0
     # via pip-tools
-certifi==2026.4.22
+certifi==2026.5.20
     # via requests
 cfgv==3.5.0
     # via pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ distlib==0.4.3
     # via virtualenv
 exceptiongroup==1.3.1
     # via pytest
-filelock==3.29.4
+filelock==3.29.5
     # via
     #   python-discovery
     #   virtualenv
@@ -53,7 +53,7 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pytest==9.1.1
     # via -r requirements.in
-python-discovery==1.4.2
+python-discovery==1.4.3
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit


### PR DESCRIPTION
## Summary

- Upgrade pinned packages in `requirements.txt` via `pip-compile -vU`
- Notable: idna 3.15→3.18 (keeps CVE-2026-45409 fix, newer than master's 3.15), pytest 9.0.3→9.1.1, requests 2.33.1→2.34.2, squiral 0.5.1→0.6.0

## Changes

### `requirements.txt`
Regenerated via `pip-compile -vU`. Upgrades: build 1.5.0→1.5.1, certifi 2026.4.22→2026.6.17, charset-normalizer 3.4.7→3.4.9, click 8.3.3→8.4.2, distlib 0.4.0→0.4.3, filelock 3.29.0→3.29.7, idna 3.15→3.18, platformdirs 4.9.6→4.10.0, pytest 9.0.3→9.1.1, python-discovery 1.3.0→1.4.4, requests 2.33.1→2.34.2, squiral 0.5.1→0.6.0, typing-extensions 4.15.0→4.16.0, virtualenv 21.3.1→21.6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)