### PR TITLE
feat(socials): track x.com links, drop mastodon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Guidance for Claude Code (claude.ai/code) in this repo.
 
 ## Project Overview
 
-Personal site automation for ctrl-c.club (~sadikkuzu). Scans user profile pages, extracts social links (Twitter, Instagram, Mastodon, GitHub), validates, generates HTML → `~/public_html/socials.html` via cron.
+Personal site automation for ctrl-c.club (~sadikkuzu). Scans user profile pages, extracts social links (Twitter, X, Instagram, GitHub), validates, generates HTML → `~/public_html/socials.html` via cron.
 
 ## Commands
 
@@ -19,6 +19,9 @@ pytest
 pytest test_socials.py::test_ayikla       # single test
 pytest test_socials.py::test_baloncuksort  # single test
 ```
+Tests hit live twitter.com — require network.
+
+Python 3.10+ (CI pins 3.10; pyupgrade uses --py310-plus).
 
 **Lint / format (pre-commit hooks):**
 ```bash
@@ -39,7 +42,7 @@ All core logic in `socials.py`:
 - `olustur(liste)` — renders `{url, username}` dicts into HTML snippet
 - `main()` — scans `/home/*/public_html/index.html` for social links via regex, validates, sorts, prints full HTML page to stdout
 
-Four global lists (`twitter`, `instagram`, `mastodon`, `github`) accumulate `{url, username}` dicts. `found` list deduplicates URLs across users.
+Four global lists (`twitter`, `x`, `instagram`, `github`) accumulate `{url, username}` dicts. `found` list deduplicates URLs across users.
 
 **Cron schedule (documented in README):**
 ```

--- a/socials.py
+++ b/socials.py
@@ -8,8 +8,8 @@ import re
 import requests
 
 twitter: list[dict] = []
+x: list[dict] = []
 instagram: list[dict] = []
-mastodon: list[dict] = []
 github: list[dict] = []
 found: list[str] = []
 
@@ -42,7 +42,7 @@ def baloncuksort(liste, balon):
 
 
 def olustur(liste):
-    adi = [k for k, v in globals().items() if v == liste][0]
+    adi = [k for k, v in globals().items() if v is liste][0]
     harf = adi[0].upper()
     print(f"<strong>[*] {str(adi)}</strong> ({str(len(liste))})<br>")
     for item in liste:
@@ -57,8 +57,8 @@ def olustur(liste):
 
 def main():
     global twitter
+    global x
     global instagram
-    global mastodon
     global github
 
     for filename in os.listdir("/home"):
@@ -69,12 +69,12 @@ def main():
             continue
 
         tw = re.findall(r"twitter\.com\/[a-z0-9A-Z_]+", s)
-        ma = re.findall(r"[a-zA-Z0-9\.]+\/@[a-z0-9A-Z_]+", s)
+        xc = re.findall(r"\bx\.com\/[a-z0-9A-Z_]+", s)
         ig = re.findall(r"instagram\.com\/[a-z0-9A-Z._]+", s)
         gh = re.findall(r"https://github\.com\/[a-z0-9A-Z_]+", s)
 
         ayikla(tw)
-        # ayikla(ma)
+        ayikla(xc)
         # ayikla(ig)
         ayikla(gh)
 
@@ -89,10 +89,10 @@ def main():
                     )
                     found.append(item)
 
-        if len(ma):
-            for item in ma:
-                if item not in found and "medium.com" not in item:
-                    mastodon.append(
+        if len(xc):
+            for item in xc:
+                if item not in found:
+                    x.append(
                         {
                             "url": item,
                             "username": filename,
@@ -125,7 +125,7 @@ def main():
     bubble = "sadikkuzu"
     github = baloncuksort(github, bubble)
     twitter = baloncuksort(twitter, bubble)
-    mastodon = baloncuksort(mastodon, bubble)
+    x = baloncuksort(x, bubble)
     instagram = baloncuksort(instagram, bubble)
 
     print(
@@ -139,12 +139,12 @@ def main():
     simdi: str = str(datetime.datetime.now())
     print(f"[*] <strong>Updated at :</strong> {simdi}<br>")
 
-    total_count = len(github) + len(twitter) + len(mastodon) + len(instagram)
+    total_count = len(github) + len(twitter) + len(x) + len(instagram)
     print(f"[*] <strong>Total count:</strong> {total_count}<br><br>")
 
     olustur(github)
     olustur(twitter)
-    olustur(mastodon)
+    olustur(x)
     olustur(instagram)
 
     print(


### PR DESCRIPTION
## Summary
- Scan `x.com` profile links alongside `twitter.com` (users migrated after rebrand); rendered as own section
- Remove mastodon group: regex, list, output
- Fix `olustur` name lookup: `==` matched any empty global list, `is` compares identity
- CLAUDE.md synced: group list updated, notes on live-network tests and Python 3.10 floor

## Details
- `\bx\.com` pattern verified against false positives (dropbox.com, netflix.com, 0x.com)
- `x.com` links validated live via `ayikla`, deduped via `found`, bubble-sorted like other groups

## Test plan
- `pytest` — 7 passed
- `pre-commit run --all-files` — 14 hooks passed (black, flake8, mypy, shellcheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)