### PR TITLE
Fix upgrader workflow and upgrade dependencies

### DIFF
--- a/.github/workflows/upgrader.yml
+++ b/.github/workflows/upgrader.yml
@@ -39,8 +39,8 @@ jobs:
     - name: Run pip-compile, install requirements, and pre-commit autoupdate
       run: |
         python -m pip install --upgrade pip
-        pip install pip-tools || python -m pip install pip==25.0 && pip install pip-tools
-        pip-compile -vU || python -m pip install pip==25.0 && pip install pip-tools && pip-compile -vU
+        pip install pip-tools
+        pip-compile -vU
         pip install -r requirements.txt
         pre-commit autoupdate
         pre-commit run --all-files --color always

--- a/.github/workflows/upgrader.yml
+++ b/.github/workflows/upgrader.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Run pip-compile, install requirements, and pre-commit autoupdate
       run: |
         python -m pip install --upgrade pip
-        pip install pip-tools
+        pip install pip-tools typing_extensions
         pip-compile -vU
         pip install -r requirements.txt
         pre-commit autoupdate

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ distlib==0.4.3
     # via virtualenv
 exceptiongroup==1.3.1
     # via pytest
-filelock==3.30.2
+filelock==3.30.3
     # via
     #   python-discovery
     #   virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ distlib==0.4.3
     # via virtualenv
 exceptiongroup==1.3.1
     # via pytest
-filelock==3.29.7
+filelock==3.30.2
     # via
     #   python-discovery
     #   virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ distlib==0.4.3
     # via virtualenv
 exceptiongroup==1.3.1
     # via pytest
-filelock==3.30.3
+filelock==3.31.0
     # via
     #   python-discovery
     #   virtualenv
@@ -35,9 +35,9 @@ packaging==26.2
     #   build
     #   pytest
     #   wheel
-pip-tools==7.5.3
+pip-tools==7.6.0
     # via -r requirements.in
-platformdirs==4.10.0
+platformdirs==4.10.1
     # via
     #   python-discovery
     #   virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-build==1.5.1
+build==1.5.0
     # via pip-tools
 certifi==2026.6.17
     # via requests


### PR DESCRIPTION
## Summary

- Simplify pip-tools installation commands in the upgrader workflow (drop obsolete `pip==25.0` fallback chains)
- Install `typing_extensions` alongside pip-tools: pip-tools 7.6.0 imports it in `writer.py` but omits it from its declared dependencies, crashing `pip-compile` on a fresh Python 3.10 env ([failed run](https://github.com/sadikkuzu/ctrl-c-club/actions/runs/29698241204))
- Dependency upgrades from the scheduled upgrader: `filelock` 3.30.3→3.31.0, `pip-tools` 7.5.3→7.6.0, `platformdirs` 4.10.0→4.10.1

## Test plan

- [x] Upgrader workflow green after fix: [run 29698320343](https://github.com/sadikkuzu/ctrl-c-club/actions/runs/29698320343) — `pip-compile`, `pip install -r requirements.txt`, and pre-commit all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)